### PR TITLE
Additional Properties not allowed, ReVAL pinned

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-django-data-ingest = {editable = true,git = "https://github.com/18F/django-data-ingest.git",ref = "master"}
+data-ingest = {editable = true,git = "https://github.com/18F/ReVAL.git",ref = "v0.4.0"}
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "89855ef72091dc924aa36878662d2b5162161537fa13d094f0f61908785c62c8"
+            "sha256": "8e34ceec6be76835ed6cdd4e5d61e789b170ac91477eeb5fc21529f6da03f118"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -53,10 +53,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
-                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
             ],
-            "version": "==2019.3.9"
+            "version": "==2019.6.16"
         },
         "chardet": {
             "hashes": [
@@ -74,9 +74,14 @@
         },
         "click-default-group": {
             "hashes": [
-                "sha256:ba8c43d9c384e1ea7127484c5fc8f4e1ca759519a64fff10718d53f4b82c412a"
+                "sha256:31f6f22fcb3d558172badd51fde3c444af9c9d5af8480c5540b51db6805ffa29"
             ],
-            "version": "==1.2"
+            "version": "==1.2.1"
+        },
+        "data-ingest": {
+            "editable": true,
+            "git": "https://github.com/18F/ReVAL.git",
+            "ref": "fa1d3d317e57799cef84a6c546a3a1f8f44e9c7e"
         },
         "datapackage": {
             "hashes": [
@@ -98,11 +103,6 @@
                 "sha256:ba723e524facffa2a9d8c2e9116db871e16b9207e648e1d3e4af8aae1167b029"
             ],
             "version": "==1.11.21"
-        },
-        "django-data-ingest": {
-            "editable": true,
-            "git": "https://github.com/18F/django-data-ingest.git",
-            "ref": "3670028a2a01dccd10befc3f022c7fcffb16adf4"
         },
         "djangorestframework": {
             "hashes": [
@@ -141,10 +141,20 @@
         },
         "ijson": {
             "hashes": [
-                "sha256:ef5f9f6bf9e44f2e1721e72bcc82c7ac6bb012b525e0f8642dedf7ddc44cf474",
-                "sha256:eff9ce137698dcb565420497050955cb811892eb073ea1c09d92ecaf671bd7f7"
+                "sha256:165f51858dbde00a714f06ecec067adb81016188699a78f2afc2300abfdf7ad6",
+                "sha256:3fccd8e0808b603afe8594f6fbf1b71cc3e69bc7eedec5b7a88d828448b8d21c",
+                "sha256:558dd253510314087f960a81e5bef5fdce8abb3576626bdc38736f95c2cf51c0",
+                "sha256:659ea9f2ab515b39cc72e604e64c4fcce7d66dbbda281b4cf76066be1a37f2fe",
+                "sha256:8145053b83c24a42313d616a92cc46a06fcf1365bc3dd4f97b4be69bf8f4b92c",
+                "sha256:88911b226d718af9a217746bae0859ae7e9e4c211ba97d1e1744a29726d57672",
+                "sha256:b405b4411ea5668832edc7aa4ea1a34536e7917a9d24edee2031a7caa6597b06",
+                "sha256:b78bbb5617716ebf47aff67932bee4ec811909ef69b93c3925b2fe1f0fe4b98c",
+                "sha256:ca97e844a23729e06608465a0c24f57d4ce89299fa1640fddd165847d319c99a",
+                "sha256:d8a927a72c69df4a786943a514c9cd63621b76eac8143b11d58e7c625c81ba74",
+                "sha256:e6307625812a663dd0ee9c398087340a79e77b1e26ff7532bf537980df167ddd",
+                "sha256:f7f88203b41e1ceb5ebc9b2de804005923b78ff86af431ecbad65c3078e65f0d"
             ],
-            "version": "==2.3"
+            "version": "==2.4"
         },
         "isodate": {
             "hashes": [
@@ -201,36 +211,36 @@
         },
         "psycopg2-binary": {
             "hashes": [
-                "sha256:007ca0df127b1862fc010125bc4100b7a630efc6841047bd11afceadb4754611",
-                "sha256:03c49e02adf0b4d68f422fdbd98f7a7c547beb27e99a75ed02298f85cb48406a",
-                "sha256:0a1232cdd314e08848825edda06600455ad2a7adaa463ebfb12ece2d09f3370e",
-                "sha256:131c80d0958c89273d9720b9adf9df1d7600bb3120e16019a7389ab15b079af5",
-                "sha256:2de34cc3b775724623f86617d2601308083176a495f5b2efc2bbb0da154f483a",
-                "sha256:2eddc31500f73544a2a54123d4c4b249c3c711d31e64deddb0890982ea37397a",
-                "sha256:484f6c62bdc166ee0e5be3aa831120423bf399786d1f3b0304526c86180fbc0b",
-                "sha256:4c2d9369ed40b4a44a8ccd6bc3a7db6272b8314812d2d1091f95c4c836d92e06",
-                "sha256:70f570b5fa44413b9f30dbc053d17ef3ce6a4100147a10822f8662e58d473656",
-                "sha256:7a2b5b095f3bd733aab101c89c0e1a3f0dfb4ebdc26f6374805c086ffe29d5b2",
-                "sha256:804914a669186e2843c1f7fbe12b55aad1b36d40a28274abe6027deffad9433d",
-                "sha256:8520c03172da18345d012949a53617a963e0191ccb3c666f23276d5326af27b5",
-                "sha256:90da901fc33ea393fc644607e4a3916b509387e9339ec6ebc7bfded45b7a0ae9",
-                "sha256:a582416ad123291a82c300d1d872bdc4136d69ad0b41d57dc5ca3df7ef8e3088",
-                "sha256:ac8c5e20309f4989c296d62cac20ee456b69c41fd1bc03829e27de23b6fa9dd0",
-                "sha256:b2cf82f55a619879f8557fdaae5cec7a294fac815e0087c4f67026fdf5259844",
-                "sha256:b59d6f8cfca2983d8fdbe457bf95d2192f7b7efdb2b483bf5fa4e8981b04e8b2",
-                "sha256:be08168197021d669b9964bd87628fa88f910b1be31e7010901070f2540c05fd",
-                "sha256:be0f952f1c365061041bad16e27e224e29615d4eb1fb5b7e7760a1d3d12b90b6",
-                "sha256:c1c9a33e46d7c12b9c96cf2d4349d783e3127163fd96254dcd44663cf0a1d438",
-                "sha256:d18c89957ac57dd2a2724ecfe9a759912d776f96ecabba23acb9ecbf5c731035",
-                "sha256:d7e7b0ff21f39433c50397e60bf0995d078802c591ca3b8d99857ea18a7496ee",
-                "sha256:da0929b2bf0d1f365345e5eb940d8713c1d516312e010135b14402e2a3d2404d",
-                "sha256:de24a4962e361c512d3e528ded6c7480eab24c655b8ca1f0b761d3b3650d2f07",
-                "sha256:e45f93ff3f7dae2202248cf413a87aeb330821bf76998b3cf374eda2fc893dd7",
-                "sha256:f046aeae1f7a845041b8661bb7a52449202b6c5d3fb59eb4724e7ca088811904",
-                "sha256:f1dc2b7b2748084b890f5d05b65a47cd03188824890e9a60818721fd492249fb",
-                "sha256:fcbe7cf3a786572b73d2cd5f34ed452a5f5fac47c9c9d1e0642c457a148f9f88"
+                "sha256:080c72714784989474f97be9ab0ddf7b2ad2984527e77f2909fcd04d4df53809",
+                "sha256:110457be80b63ff4915febb06faa7be002b93a76e5ba19bf3f27636a2ef58598",
+                "sha256:171352a03b22fc099f15103959b52ee77d9a27e028895d7e5fde127aa8e3bac5",
+                "sha256:19d013e7b0817087517a4b3cab39c084d78898369e5c46258aab7be4f233d6a1",
+                "sha256:249b6b21ae4eb0f7b8423b330aa80fab5f821b9ffc3f7561a5e2fd6bb142cf5d",
+                "sha256:2ac0731d2d84b05c7bb39e85b7e123c3a0acd4cda631d8d542802c88deb9e87e",
+                "sha256:2b6d561193f0dc3f50acfb22dd52ea8c8dfbc64bcafe3938b5f209cc17cb6f00",
+                "sha256:2bd23e242e954214944481124755cbefe7c2cf563b1a54cd8d196d502f2578bf",
+                "sha256:3e1239242ca60b3725e65ab2f13765fc199b03af9eaf1b5572f0e97bdcee5b43",
+                "sha256:3eb70bb697abbe86b1d2b1316370c02ba320bfd1e9e35cf3b9566a855ea8e4e5",
+                "sha256:51a2fc7e94b98bd1bb5d4570936f24fc2b0541b63eccadf8fdea266db8ad2f70",
+                "sha256:52f1bdafdc764b7447e393ed39bb263eccb12bfda25a4ac06d82e3a9056251f6",
+                "sha256:5b3581319a3951f1e866f4f6c5e42023db0fae0284273b82e97dfd32c51985cd",
+                "sha256:63c1b66e3b2a3a336288e4bcec499e0dc310cd1dceaed1c46fa7419764c68877",
+                "sha256:8123a99f24ecee469e5c1339427bcdb2a33920a18bb5c0d58b7c13f3b0298ba3",
+                "sha256:85e699fcabe7f817c0f0a412d4e7c6627e00c412b418da7666ff353f38e30f67",
+                "sha256:8dbff4557bbef963697583366400822387cccf794ccb001f1f2307ed21854c68",
+                "sha256:908d21d08d6b81f1b7e056bbf40b2f77f8c499ab29e64ec5113052819ef1c89b",
+                "sha256:af39d0237b17d0a5a5f638e9dffb34013ce2b1d41441fd30283e42b22d16858a",
+                "sha256:af51bb9f055a3f4af0187149a8f60c9d516cf7d5565b3dac53358796a8fb2a5b",
+                "sha256:b2ecac57eb49e461e86c092761e6b8e1fd9654dbaaddf71a076dcc869f7014e2",
+                "sha256:cd37cc170678a4609becb26b53a2bc1edea65177be70c48dd7b39a1149cabd6e",
+                "sha256:d17e3054b17e1a6cb8c1140f76310f6ede811e75b7a9d461922d2c72973f583e",
+                "sha256:d305313c5a9695f40c46294d4315ed3a07c7d2b55e48a9010dad7db7a66c8b7f",
+                "sha256:dd0ef0eb1f7dd18a3f4187226e226a7284bda6af5671937a221766e6ef1ee88f",
+                "sha256:e1adff53b56db9905db48a972fb89370ad5736e0450b96f91bcf99cadd96cfd7",
+                "sha256:f0d43828003c82dbc9269de87aa449e9896077a71954fbbb10a614c017e65737",
+                "sha256:f78e8b487de4d92640105c1389e5b90be3496b1d75c90a666edd8737cc2dbab7"
             ],
-            "version": "==2.8.2"
+            "version": "==2.8.3"
         },
         "pyrsistent": {
             "hashes": [
@@ -297,9 +307,9 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:c7fef198b43ef31dfd783d094fd5ee435ce8717592e6784c45ba337254998017"
+                "sha256:c30925d60af95443458ebd7525daf791f55762b106049ae71e18f8dd58084c2f"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         },
         "statistics": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # usdot-jpo-ode-workzone-data-exchange
 
-Workzone Data Exchange Validator is a validation service that checks JSON data against the [WZDx v1.1 specification](https://github.com/usdot-jpo-ode/jpo-wzdx/blob/master/full-spec/full-spec.md).  This project uses [ReVAL (Django Data Ingest)](https://github.com/18F/django-data-ingest) to perform JSON Schema validation.
+Workzone Data Exchange Validator is a validation service that checks JSON data against the [WZDx v1.1 specification](https://github.com/usdot-jpo-ode/jpo-wzdx/blob/master/full-spec/full-spec.md).  This project uses [ReVAL](https://github.com/18F/ReVAL) to perform JSON Schema validation.
 
 Please note that WZDx v1.1 specification is written in XML, therefore, the [JSON schema](https://github.com/18F/usdot-jpo-ode-workzone-data-exchange/blob/master/schema.json) provided here is derived from the XML version.  More specifically, it was derived from the [WZDx_final01.xsd file](https://github.com/usdot-jpo-ode/jpo-wzdx/blob/master/sample-files/WZDx_final01.xsd).

--- a/data/fake_invalid_sample.json
+++ b/data/fake_invalid_sample.json
@@ -1,0 +1,102 @@
+[
+  {
+    "identifier": 5220,
+    "StartDateTime": {
+      "startDateTime-est": "2017-06-12 16:30:00",
+      "startDateTime-ver": "2017-06-12 16:30:00",
+      "startDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "EndDateTime": {
+      "endDateTime-est": "2021-12-31 17:00:00",
+      "endDateTime-ver": "2021-12-31 17:00:00",
+      "endDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "BeginLocation": {
+      "roadName": "I-1175",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.350189,
+      "latitude-ver": -44.350189,
+      "longitude-est": 28.487378,
+      "longitude-ver": 28.487378,
+      "milepost-est": 45.0,
+      "milepost-ver": 45.0,
+      "crossStreet": null
+    },
+    "EndLocation": {
+      "roadName": "I-1175",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.350189,
+      "latitude-ver": -44.350189,
+      "longitude-est": 28.487378,
+      "longitude-ver": 28.487378,
+      "milepost-est": 54.0,
+      "milepost-ver": 54.0,
+      "crossStreet": null
+    },
+    "wz-Status": null,
+    "totalLanes": null,
+    "openLanes": null,
+    "closedLanes": null,
+    "closedShoulders": null,
+    "workersPresent": null,
+    "RoadRestritions": null,
+    "description": "Lanes blocked in both directions between mm 45 - 54 from 8am - 5pm each day for road widening work. Expect delays.",
+    "issuingOrganization": "CQT",
+    "timeStampCreation": "2017-06-12 16:54:00",
+    "timeStampUpdate": "2017-06-12 16:54:00"
+  },
+  {
+    "identifier": 5222,
+    "StartDateTime": {
+      "startDateTime-est": "2017-06-12 16:55:00",
+      "startDateTime-ver": "2017-06-12 16:55:00",
+      "startDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "EndDateTime": {
+      "endDateTime-est": "2021-07-31 17:00:00",
+      "endDateTime-ver": "2021-07-31 17:00:00",
+      "endDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "BeginLocation": {
+      "roadName": "US-0166",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.184075,
+      "latitude-ver": -44.184075,
+      "longitude-est": 29.452345,
+      "longitude-ver": 29.452345,
+      "milepost-est": 0.0,
+      "milepost-ver": 0.0,
+      "crossStreet": null
+    },
+    "EndLocation": {
+      "roadName": "US-0166",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.184075,
+      "latitude-ver": -44.184075,
+      "longitude-est": 29.452345,
+      "longitude-ver": 29.452345,
+      "milepost-est": 8.0,
+      "milepost-ver": 8.0,
+      "crossStreet": null
+    },
+    "wz-Status": null,
+    "totalLanes": null,
+    "openLanes": null,
+    "closedLanes": null,
+    "closedShoulders": null,
+    "workersPresent": null,
+    "RoadRestritions": null,
+    "description": "Look out for lane blocked between mm 0 - 8 for long-term road-widening project.",
+    "issuingOrganization": "CQT",
+    "timeStampCreation": "2017-06-12 17:04:00",
+    "timeStampUpdate": "2017-06-12 17:04:00"
+  }
+]

--- a/data/fake_invalid_sample1.json
+++ b/data/fake_invalid_sample1.json
@@ -1,0 +1,96 @@
+[
+  {
+    "identifier": "5220",
+    "startDateTime": {
+      "startDateTime-est": "2017-06-12 16:30:00",
+      "startDateTime-ver": "2017-06-12 16:30:00",
+      "startDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "endDateTime": {
+      "endDateTime-est": "2021-12-31 17:00:00",
+      "endDateTime-ver": "2021-12-31 17:00:00",
+      "endDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "beginLocation": {
+      "roadName": "I-1175",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.350189,
+      "latitude-ver": -44.350189,
+      "longitude-est": 28.487378,
+      "longitude-ver": 28.487378,
+      "milepost-est": 45.0,
+      "milepost-ver": 45.0,
+      "crossStreet": null
+    },
+    "endLocation": {
+      "roadName": "I-1175",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.350189,
+      "latitude-ver": -44.350189,
+      "longitude-est": 28.487378,
+      "longitude-ver": 28.487378,
+      "milepost-est": 54.0,
+      "milepost-ver": 54.0,
+      "crossStreet": null
+    },
+    "wz_status": "Active",
+    "totalLanes": "4",
+    "openLanes": "none",
+    "closedLanes": "all",
+    "closedShoulders": "unknown",
+    "workersPresent": true,
+    "roadRestrictions": ["no-trucks", "no-parking", "permitted-oversize-loads-prohibited"],
+    "description": "Lanes blocked in both directions between mm 45 - 54 from 8am - 5pm each day for road widening work. Expect delays.",
+    "issuingOrganization": "CQT",
+    "timestampEventCreation": "2017-06-12 16:54:00",
+    "timestampEventUpdate": "2017-06-12 16:54:00"
+  },
+  {
+    "identifier": "5222",
+    "startDateTime": {
+      "startDateTime-est": "2017-06-12 16:55:00",
+      "startDateTime-ver": "2017-06-12 16:55:00",
+      "startDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "endDateTime": {
+      "endDateTime-est": "2021-07-31 17:00:00",
+      "endDateTime-ver": "2021-07-31 17:00:00",
+      "endDateTime-cancelled": null,
+      "timeConfidenceLevel": null
+    },
+    "beginLocation": {
+      "roadName": "US-0166",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.184075,
+      "latitude-ver": -44.184075,
+      "longitude-est": 29.452345,
+      "longitude-ver": 29.452345,
+      "milepost-est": 0.0,
+      "milepost-ver": 0.0,
+      "crossStreet": null
+    },
+    "endLocation": {
+      "roadName": "US-0166",
+      "roadNum": null,
+      "roadDirection": null,
+      "latitude-est": -44.184075,
+      "latitude-ver": -44.184075,
+      "longitude-est": 29.452345,
+      "longitude-ver": 29.452345,
+      "milepost-est": 8.0,
+      "milepost-ver": 8.0,
+      "crossStreet": null
+    },
+    "closedLanes": "all",
+    "description": "Look out for lane blocked between mm 0 - 8 for long-term road-widening project.",
+    "issuingOrganization": "CQT",
+    "timestampEventCreation": "2017-06-12 17:04:00",
+    "timestampEventUpdate": "2017-06-12 17:04:00"
+  }
+]

--- a/data/fake_invalid_sample_response.json
+++ b/data/fake_invalid_sample_response.json
@@ -1,0 +1,279 @@
+{
+    "tables": [
+        {
+            "headers": [],
+            "whole_table_errors": [],
+            "rows": [
+                {
+                    "row_number": 0,
+                    "errors": [
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "5220 is not of type 'string'",
+                            "fields": [
+                                "identifier"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "totalLanes"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['all', 'left-lane', 'right-lane', 'left-2-lanes', 'left-3-lanes', 'right-2-lanes', 'right-3-lanes', 'middle-lane', 'middle-two-lanes', 'right-turning-lane', 'left-turning-lane', 'right-exit-lane', 'left-exit-lane', 'right-merging-lane', 'left-merging-lane', 'right-exit-ramp', 'right-second-exit-ramp', 'right-entrance-ramp', 'right-second-entrance-ramp', 'left-exit-ramp', 'left-second-exit-ramp', 'left-entrance-ramp', 'left-second-entrance-ramp', 'sidewalk', 'bike-lane', 'none', 'unknown', 'alternating-flow-lane', 'left-shift-lanes', 'right-shift-lanes']",
+                            "fields": [
+                                "openLanes"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['all', 'left-lane', 'right-lane', 'left-2-lanes', 'left-3-lanes', 'right-2-lanes', 'right-3-lanes', 'middle-lane', 'middle-two-lanes', 'right-turning-lane', 'left-turning-lane', 'right-exit-lane', 'left-exit-lane', 'right-merging-lane', 'left-merging-lane', 'right-exit-ramp', 'right-second-exit-ramp', 'right-entrance-ramp', 'right-second-entrance-ramp', 'left-exit-ramp', 'left-second-exit-ramp', 'left-entrance-ramp', 'left-second-entrance-ramp', 'sidewalk', 'bike-lane', 'none', 'unknown', 'alternating-flow-lane', 'left-shift-lanes', 'right-shift-lanes']",
+                            "fields": [
+                                "closedLanes"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['outside', 'inside', 'both', 'none', 'unknown']",
+                            "fields": [
+                                "closedShoulders"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'boolean'",
+                            "fields": [
+                                "workersPresent"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'startDateTime' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'endDateTime' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'beginLocation' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'endLocation' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "additionalProperties",
+                            "message": "Additional properties are not allowed ('RoadRestritions', 'wz-Status', 'timeStampUpdate', 'StartDateTime', 'timeStampCreation', 'EndLocation', 'BeginLocation', 'EndDateTime' were unexpected)",
+                            "fields": []
+                        }
+                    ],
+                    "data": {
+                        "identifier": 5220,
+                        "StartDateTime": {
+                            "startDateTime-est": "2017-06-12 16:30:00",
+                            "startDateTime-ver": "2017-06-12 16:30:00",
+                            "startDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "EndDateTime": {
+                            "endDateTime-est": "2021-12-31 17:00:00",
+                            "endDateTime-ver": "2021-12-31 17:00:00",
+                            "endDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "BeginLocation": {
+                            "roadName": "I-1175",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.350189,
+                            "latitude-ver": -44.350189,
+                            "longitude-est": 28.487378,
+                            "longitude-ver": 28.487378,
+                            "milepost-est": 45.0,
+                            "milepost-ver": 45.0,
+                            "crossStreet": null
+                        },
+                        "EndLocation": {
+                            "roadName": "I-1175",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.350189,
+                            "latitude-ver": -44.350189,
+                            "longitude-est": 28.487378,
+                            "longitude-ver": 28.487378,
+                            "milepost-est": 54.0,
+                            "milepost-ver": 54.0,
+                            "crossStreet": null
+                        },
+                        "wz-Status": null,
+                        "totalLanes": null,
+                        "openLanes": null,
+                        "closedLanes": null,
+                        "closedShoulders": null,
+                        "workersPresent": null,
+                        "RoadRestritions": null,
+                        "description": "Lanes blocked in both directions between mm 45 - 54 from 8am - 5pm each day for road widening work. Expect delays.",
+                        "issuingOrganization": "CQT",
+                        "timeStampCreation": "2017-06-12 16:54:00",
+                        "timeStampUpdate": "2017-06-12 16:54:00"
+                    }
+                },
+                {
+                    "row_number": 1,
+                    "errors": [
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "5222 is not of type 'string'",
+                            "fields": [
+                                "identifier"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "totalLanes"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['all', 'left-lane', 'right-lane', 'left-2-lanes', 'left-3-lanes', 'right-2-lanes', 'right-3-lanes', 'middle-lane', 'middle-two-lanes', 'right-turning-lane', 'left-turning-lane', 'right-exit-lane', 'left-exit-lane', 'right-merging-lane', 'left-merging-lane', 'right-exit-ramp', 'right-second-exit-ramp', 'right-entrance-ramp', 'right-second-entrance-ramp', 'left-exit-ramp', 'left-second-exit-ramp', 'left-entrance-ramp', 'left-second-entrance-ramp', 'sidewalk', 'bike-lane', 'none', 'unknown', 'alternating-flow-lane', 'left-shift-lanes', 'right-shift-lanes']",
+                            "fields": [
+                                "openLanes"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['all', 'left-lane', 'right-lane', 'left-2-lanes', 'left-3-lanes', 'right-2-lanes', 'right-3-lanes', 'middle-lane', 'middle-two-lanes', 'right-turning-lane', 'left-turning-lane', 'right-exit-lane', 'left-exit-lane', 'right-merging-lane', 'left-merging-lane', 'right-exit-ramp', 'right-second-exit-ramp', 'right-entrance-ramp', 'right-second-entrance-ramp', 'left-exit-ramp', 'left-second-exit-ramp', 'left-entrance-ramp', 'left-second-entrance-ramp', 'sidewalk', 'bike-lane', 'none', 'unknown', 'alternating-flow-lane', 'left-shift-lanes', 'right-shift-lanes']",
+                            "fields": [
+                                "closedLanes"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['outside', 'inside', 'both', 'none', 'unknown']",
+                            "fields": [
+                                "closedShoulders"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'boolean'",
+                            "fields": [
+                                "workersPresent"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'startDateTime' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'endDateTime' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'beginLocation' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "required",
+                            "message": "'endLocation' is a required property",
+                            "fields": []
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "additionalProperties",
+                            "message": "Additional properties are not allowed ('RoadRestritions', 'wz-Status', 'timeStampUpdate', 'StartDateTime', 'timeStampCreation', 'EndLocation', 'BeginLocation', 'EndDateTime' were unexpected)",
+                            "fields": []
+                        }
+                    ],
+                    "data": {
+                        "identifier": 5222,
+                        "StartDateTime": {
+                            "startDateTime-est": "2017-06-12 16:55:00",
+                            "startDateTime-ver": "2017-06-12 16:55:00",
+                            "startDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "EndDateTime": {
+                            "endDateTime-est": "2021-07-31 17:00:00",
+                            "endDateTime-ver": "2021-07-31 17:00:00",
+                            "endDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "BeginLocation": {
+                            "roadName": "US-0166",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.184075,
+                            "latitude-ver": -44.184075,
+                            "longitude-est": 29.452345,
+                            "longitude-ver": 29.452345,
+                            "milepost-est": 0.0,
+                            "milepost-ver": 0.0,
+                            "crossStreet": null
+                        },
+                        "EndLocation": {
+                            "roadName": "US-0166",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.184075,
+                            "latitude-ver": -44.184075,
+                            "longitude-est": 29.452345,
+                            "longitude-ver": 29.452345,
+                            "milepost-est": 8.0,
+                            "milepost-ver": 8.0,
+                            "crossStreet": null
+                        },
+                        "wz-Status": null,
+                        "totalLanes": null,
+                        "openLanes": null,
+                        "closedLanes": null,
+                        "closedShoulders": null,
+                        "workersPresent": null,
+                        "RoadRestritions": null,
+                        "description": "Look out for lane blocked between mm 0 - 8 for long-term road-widening project.",
+                        "issuingOrganization": "CQT",
+                        "timeStampCreation": "2017-06-12 17:04:00",
+                        "timeStampUpdate": "2017-06-12 17:04:00"
+                    }
+                }
+            ],
+            "valid_row_count": 0,
+            "invalid_row_count": 2
+        }
+    ],
+    "valid": false
+}

--- a/data/fake_invalid_sample_response1.json
+++ b/data/fake_invalid_sample_response1.json
@@ -1,0 +1,409 @@
+{
+    "tables": [
+        {
+            "headers": [],
+            "whole_table_errors": [],
+            "rows": [
+                {
+                    "row_number": 0,
+                    "errors": [
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "startDateTime",
+                                "startDateTime-cancelled"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'number'",
+                            "fields": [
+                                "startDateTime",
+                                "timeConfidenceLevel"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'startDateTime-est': '2017-06-12 16:30:00', 'startDateTime-ver': '2017-06-12 16:30:00', 'startDateTime-cancelled': None, 'timeConfidenceLevel': None} is valid under each of {'required': ['startDateTime-ver']}, {'required': ['startDateTime-cancelled']}, {'required': ['startDateTime-est']}",
+                            "fields": [
+                                "startDateTime"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "endDateTime",
+                                "endDateTime-cancelled"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'number'",
+                            "fields": [
+                                "endDateTime",
+                                "timeConfidenceLevel"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'endDateTime-est': '2021-12-31 17:00:00', 'endDateTime-ver': '2021-12-31 17:00:00', 'endDateTime-cancelled': None, 'timeConfidenceLevel': None} is valid under each of {'required': ['endDateTime-ver']}, {'required': ['endDateTime-cancelled']}, {'required': ['endDateTime-est']}",
+                            "fields": [
+                                "endDateTime"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "beginLocation",
+                                "roadNum"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['northbound', 'eastbound', 'southbound', 'westbound']",
+                            "fields": [
+                                "beginLocation",
+                                "roadDirection"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "beginLocation",
+                                "crossStreet"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'I-1175', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.350189, 'latitude-ver': -44.350189, 'longitude-est': 28.487378, 'longitude-ver': 28.487378, 'milepost-est': 45.0, 'milepost-ver': 45.0, 'crossStreet': None} is valid under each of {'required': ['latitude-ver']}, {'required': ['latitude-est']}",
+                            "fields": [
+                                "beginLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'I-1175', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.350189, 'latitude-ver': -44.350189, 'longitude-est': 28.487378, 'longitude-ver': 28.487378, 'milepost-est': 45.0, 'milepost-ver': 45.0, 'crossStreet': None} is valid under each of {'required': ['longitude-ver']}, {'required': ['longitude-est']}",
+                            "fields": [
+                                "beginLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'I-1175', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.350189, 'latitude-ver': -44.350189, 'longitude-est': 28.487378, 'longitude-ver': 28.487378, 'milepost-est': 45.0, 'milepost-ver': 45.0, 'crossStreet': None} is valid under each of {'required': ['milepost-ver']}, {'required': ['milepost-est']}",
+                            "fields": [
+                                "beginLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "endLocation",
+                                "crossStreet"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'I-1175', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.350189, 'latitude-ver': -44.350189, 'longitude-est': 28.487378, 'longitude-ver': 28.487378, 'milepost-est': 54.0, 'milepost-ver': 54.0, 'crossStreet': None} is valid under each of {'required': ['latitude-ver']}, {'required': ['latitude-est']}",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'I-1175', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.350189, 'latitude-ver': -44.350189, 'longitude-est': 28.487378, 'longitude-ver': 28.487378, 'milepost-est': 54.0, 'milepost-ver': 54.0, 'crossStreet': None} is valid under each of {'required': ['longitude-ver']}, {'required': ['longitude-est']}",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'I-1175', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.350189, 'latitude-ver': -44.350189, 'longitude-est': 28.487378, 'longitude-ver': 28.487378, 'milepost-est': 54.0, 'milepost-ver': 54.0, 'crossStreet': None} is valid under each of {'required': ['milepost-ver']}, {'required': ['milepost-est']}",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "additionalProperties",
+                            "message": "Additional properties are not allowed ('roadDirection', 'roadName', 'roadNum' were unexpected)",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        }
+                    ],
+                    "data": {
+                        "identifier": "5220",
+                        "startDateTime": {
+                            "startDateTime-est": "2017-06-12 16:30:00",
+                            "startDateTime-ver": "2017-06-12 16:30:00",
+                            "startDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "endDateTime": {
+                            "endDateTime-est": "2021-12-31 17:00:00",
+                            "endDateTime-ver": "2021-12-31 17:00:00",
+                            "endDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "beginLocation": {
+                            "roadName": "I-1175",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.350189,
+                            "latitude-ver": -44.350189,
+                            "longitude-est": 28.487378,
+                            "longitude-ver": 28.487378,
+                            "milepost-est": 45.0,
+                            "milepost-ver": 45.0,
+                            "crossStreet": null
+                        },
+                        "endLocation": {
+                            "roadName": "I-1175",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.350189,
+                            "latitude-ver": -44.350189,
+                            "longitude-est": 28.487378,
+                            "longitude-ver": 28.487378,
+                            "milepost-est": 54.0,
+                            "milepost-ver": 54.0,
+                            "crossStreet": null
+                        },
+                        "wz_status": "Active",
+                        "totalLanes": "4",
+                        "openLanes": "none",
+                        "closedLanes": "all",
+                        "closedShoulders": "unknown",
+                        "workersPresent": true,
+                        "roadRestrictions": [
+                            "no-trucks",
+                            "no-parking",
+                            "permitted-oversize-loads-prohibited"
+                        ],
+                        "description": "Lanes blocked in both directions between mm 45 - 54 from 8am - 5pm each day for road widening work. Expect delays.",
+                        "issuingOrganization": "CQT",
+                        "timestampEventCreation": "2017-06-12 16:54:00",
+                        "timestampEventUpdate": "2017-06-12 16:54:00"
+                    }
+                },
+                {
+                    "row_number": 1,
+                    "errors": [
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "startDateTime",
+                                "startDateTime-cancelled"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'number'",
+                            "fields": [
+                                "startDateTime",
+                                "timeConfidenceLevel"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'startDateTime-est': '2017-06-12 16:55:00', 'startDateTime-ver': '2017-06-12 16:55:00', 'startDateTime-cancelled': None, 'timeConfidenceLevel': None} is valid under each of {'required': ['startDateTime-ver']}, {'required': ['startDateTime-cancelled']}, {'required': ['startDateTime-est']}",
+                            "fields": [
+                                "startDateTime"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "endDateTime",
+                                "endDateTime-cancelled"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'number'",
+                            "fields": [
+                                "endDateTime",
+                                "timeConfidenceLevel"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'endDateTime-est': '2021-07-31 17:00:00', 'endDateTime-ver': '2021-07-31 17:00:00', 'endDateTime-cancelled': None, 'timeConfidenceLevel': None} is valid under each of {'required': ['endDateTime-ver']}, {'required': ['endDateTime-cancelled']}, {'required': ['endDateTime-est']}",
+                            "fields": [
+                                "endDateTime"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "beginLocation",
+                                "roadNum"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "enum",
+                            "message": "None is not one of ['northbound', 'eastbound', 'southbound', 'westbound']",
+                            "fields": [
+                                "beginLocation",
+                                "roadDirection"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "beginLocation",
+                                "crossStreet"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'US-0166', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.184075, 'latitude-ver': -44.184075, 'longitude-est': 29.452345, 'longitude-ver': 29.452345, 'milepost-est': 0.0, 'milepost-ver': 0.0, 'crossStreet': None} is valid under each of {'required': ['latitude-ver']}, {'required': ['latitude-est']}",
+                            "fields": [
+                                "beginLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'US-0166', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.184075, 'latitude-ver': -44.184075, 'longitude-est': 29.452345, 'longitude-ver': 29.452345, 'milepost-est': 0.0, 'milepost-ver': 0.0, 'crossStreet': None} is valid under each of {'required': ['longitude-ver']}, {'required': ['longitude-est']}",
+                            "fields": [
+                                "beginLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'US-0166', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.184075, 'latitude-ver': -44.184075, 'longitude-est': 29.452345, 'longitude-ver': 29.452345, 'milepost-est': 0.0, 'milepost-ver': 0.0, 'crossStreet': None} is valid under each of {'required': ['milepost-ver']}, {'required': ['milepost-est']}",
+                            "fields": [
+                                "beginLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "type",
+                            "message": "None is not of type 'string'",
+                            "fields": [
+                                "endLocation",
+                                "crossStreet"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'US-0166', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.184075, 'latitude-ver': -44.184075, 'longitude-est': 29.452345, 'longitude-ver': 29.452345, 'milepost-est': 8.0, 'milepost-ver': 8.0, 'crossStreet': None} is valid under each of {'required': ['latitude-ver']}, {'required': ['latitude-est']}",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'US-0166', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.184075, 'latitude-ver': -44.184075, 'longitude-est': 29.452345, 'longitude-ver': 29.452345, 'milepost-est': 8.0, 'milepost-ver': 8.0, 'crossStreet': None} is valid under each of {'required': ['longitude-ver']}, {'required': ['longitude-est']}",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "oneOf",
+                            "message": "{'roadName': 'US-0166', 'roadNum': None, 'roadDirection': None, 'latitude-est': -44.184075, 'latitude-ver': -44.184075, 'longitude-est': 29.452345, 'longitude-ver': 29.452345, 'milepost-est': 8.0, 'milepost-ver': 8.0, 'crossStreet': None} is valid under each of {'required': ['milepost-ver']}, {'required': ['milepost-est']}",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        },
+                        {
+                            "severity": "Error",
+                            "code": "additionalProperties",
+                            "message": "Additional properties are not allowed ('roadDirection', 'roadName', 'roadNum' were unexpected)",
+                            "fields": [
+                                "endLocation"
+                            ]
+                        }
+                    ],
+                    "data": {
+                        "identifier": "5222",
+                        "startDateTime": {
+                            "startDateTime-est": "2017-06-12 16:55:00",
+                            "startDateTime-ver": "2017-06-12 16:55:00",
+                            "startDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "endDateTime": {
+                            "endDateTime-est": "2021-07-31 17:00:00",
+                            "endDateTime-ver": "2021-07-31 17:00:00",
+                            "endDateTime-cancelled": null,
+                            "timeConfidenceLevel": null
+                        },
+                        "beginLocation": {
+                            "roadName": "US-0166",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.184075,
+                            "latitude-ver": -44.184075,
+                            "longitude-est": 29.452345,
+                            "longitude-ver": 29.452345,
+                            "milepost-est": 0.0,
+                            "milepost-ver": 0.0,
+                            "crossStreet": null
+                        },
+                        "endLocation": {
+                            "roadName": "US-0166",
+                            "roadNum": null,
+                            "roadDirection": null,
+                            "latitude-est": -44.184075,
+                            "latitude-ver": -44.184075,
+                            "longitude-est": 29.452345,
+                            "longitude-ver": 29.452345,
+                            "milepost-est": 8.0,
+                            "milepost-ver": 8.0,
+                            "crossStreet": null
+                        },
+                        "closedLanes": "all",
+                        "description": "Look out for lane blocked between mm 0 - 8 for long-term road-widening project.",
+                        "issuingOrganization": "CQT",
+                        "timestampEventCreation": "2017-06-12 17:04:00",
+                        "timestampEventUpdate": "2017-06-12 17:04:00"
+                    }
+                }
+            ],
+            "valid_row_count": 0,
+            "invalid_row_count": 2
+        }
+    ],
+    "valid": false
+}

--- a/data/fake_valid_sample.json
+++ b/data/fake_valid_sample.json
@@ -1,0 +1,65 @@
+[
+  {
+    "identifier": "5220",
+    "startDateTime": {
+      "startDateTime-ver": "2017-06-12 16:30:00",
+      "timeConfidenceLevel": 0.5
+    },
+    "endDateTime": {
+      "endDateTime-ver": "2021-12-31 17:00:00",
+      "timeConfidenceLevel": 0.5
+    },
+    "beginLocation": {
+      "roadName": "I-1175",
+      "roadNum": "I-1175",
+      "roadDirection": "northbound",
+      "latitude-ver": -44.350189,
+      "longitude-ver": 28.487378,
+      "milepost-ver": 45.0,
+      "crossStreet": "Washington"
+    },
+    "endLocation": {
+      "latitude-ver": -44.350189,
+      "longitude-ver": 28.487378,
+      "milepost-ver": 54.0,
+      "crossStreet": "Washington"
+    },
+    "wz_status": "Active",
+    "totalLanes": "4",
+    "openLanes": "none",
+    "closedLanes": "all",
+    "closedShoulders": "unknown",
+    "workersPresent": true,
+    "roadRestrictions": ["no-trucks", "no-parking", "permitted-oversize-loads-prohibited"],
+    "description": "Lanes blocked in both directions between mm 45 - 54 from 8am - 5pm each day for road widening work. Expect delays.",
+    "issuingOrganization": "CQT",
+    "timestampEventCreation": "2017-06-12 16:54:00",
+    "timestampEventUpdate": "2017-06-12 16:54:00"
+  },
+  {
+    "identifier": "5222",
+    "startDateTime": {
+      "startDateTime-ver": "2017-06-12 16:55:00"
+    },
+    "endDateTime": {
+      "endDateTime-ver": "2021-07-31 17:00:00"
+    },
+    "beginLocation": {
+      "roadName": "US-0166",
+      "roadDirection": "southbound",
+      "latitude-est": -44.184075,
+      "longitude-ver": 29.452345,
+      "milepost-ver": 0.0
+    },
+    "endLocation": {
+      "latitude-est": -44.184075,
+      "longitude-est": 29.452345,
+      "milepost-ver": 8.0
+    },
+    "closedLanes": "all",
+    "description": "Look out for lane blocked between mm 0 - 8 for long-term road-widening project.",
+    "issuingOrganization": "CQT",
+    "timestampEventCreation": "2017-06-12 17:04:00",
+    "timestampEventUpdate": "2017-06-12 17:04:00"
+  }
+]

--- a/data/fake_valid_sample_response.json
+++ b/data/fake_valid_sample_response.json
@@ -1,0 +1,88 @@
+{
+    "tables": [
+        {
+            "headers": [],
+            "whole_table_errors": [],
+            "rows": [
+                {
+                    "row_number": 0,
+                    "errors": [],
+                    "data": {
+                        "identifier": "5220",
+                        "startDateTime": {
+                            "startDateTime-ver": "2017-06-12 16:30:00",
+                            "timeConfidenceLevel": 0.5
+                        },
+                        "endDateTime": {
+                            "endDateTime-ver": "2021-12-31 17:00:00",
+                            "timeConfidenceLevel": 0.5
+                        },
+                        "beginLocation": {
+                            "roadName": "I-1175",
+                            "roadNum": "I-1175",
+                            "roadDirection": "northbound",
+                            "latitude-ver": -44.350189,
+                            "longitude-ver": 28.487378,
+                            "milepost-ver": 45.0,
+                            "crossStreet": "Washington"
+                        },
+                        "endLocation": {
+                            "latitude-ver": -44.350189,
+                            "longitude-ver": 28.487378,
+                            "milepost-ver": 54.0,
+                            "crossStreet": "Washington"
+                        },
+                        "wz_status": "Active",
+                        "totalLanes": "4",
+                        "openLanes": "none",
+                        "closedLanes": "all",
+                        "closedShoulders": "unknown",
+                        "workersPresent": true,
+                        "roadRestrictions": [
+                            "no-trucks",
+                            "no-parking",
+                            "permitted-oversize-loads-prohibited"
+                        ],
+                        "description": "Lanes blocked in both directions between mm 45 - 54 from 8am - 5pm each day for road widening work. Expect delays.",
+                        "issuingOrganization": "CQT",
+                        "timestampEventCreation": "2017-06-12 16:54:00",
+                        "timestampEventUpdate": "2017-06-12 16:54:00"
+                    }
+                },
+                {
+                    "row_number": 1,
+                    "errors": [],
+                    "data": {
+                        "identifier": "5222",
+                        "startDateTime": {
+                            "startDateTime-ver": "2017-06-12 16:55:00"
+                        },
+                        "endDateTime": {
+                            "endDateTime-ver": "2021-07-31 17:00:00"
+                        },
+                        "beginLocation": {
+                            "roadName": "US-0166",
+                            "roadDirection": "southbound",
+                            "latitude-est": -44.184075,
+                            "longitude-ver": 29.452345,
+                            "milepost-ver": 0.0
+                        },
+                        "endLocation": {
+                            "latitude-est": -44.184075,
+                            "longitude-est": 29.452345,
+                            "milepost-ver": 8.0
+                        },
+                        "closedLanes": "all",
+                        "description": "Look out for lane blocked between mm 0 - 8 for long-term road-widening project.",
+                        "issuingOrganization": "CQT",
+                        "timestampEventCreation": "2017-06-12 17:04:00",
+                        "timestampEventUpdate": "2017-06-12 17:04:00"
+                    }
+                }
+            ],
+            "valid_row_count": 2,
+            "invalid_row_count": 0
+        }
+    ],
+    "valid": true
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 -i https://pypi.org/simple
--e git+https://github.com/18F/django-data-ingest.git@3670028a2a01dccd10befc3f022c7fcffb16adf4#egg=django-data-ingest
+-e git+https://github.com/18F/ReVAL.git@fa1d3d317e57799cef84a6c546a3a1f8f44e9c7e#egg=data-ingest
 attrs==19.1.0
 cchardet==2.1.4
-certifi==2019.3.9
+certifi==2019.6.16
 chardet==3.0.4
-click-default-group==1.2
+click-default-group==1.2.1
 click==7.0
 datapackage==1.6.2
 dj-database-url==0.5.0
@@ -14,7 +14,7 @@ docutils==0.14
 et-xmlfile==1.0.1
 goodtables==2.1.6
 idna==2.8
-ijson==2.3
+ijson==2.4
 isodate==0.6.0
 jdcal==1.4.1
 json-logic-qubit==0.9.1
@@ -23,7 +23,7 @@ jsonpointer==2.0
 jsonschema==3.0.1
 linear-tsv==1.1.0
 openpyxl==2.4.11
-psycopg2-binary==2.8.2
+psycopg2-binary==2.8.3
 pyrsistent==0.15.2
 python-dateutil==2.8.0
 pytz==2019.1
@@ -32,7 +32,7 @@ requests==2.22.0
 rfc3986==1.3.2
 simpleeval==0.9.8
 six==1.12.0
-sqlalchemy==1.3.4
+sqlalchemy==1.3.5
 statistics==1.0.3.5
 tableschema==1.5.2
 tabulator==1.21.0

--- a/schema.json
+++ b/schema.json
@@ -56,7 +56,7 @@
                 "axle-load-limit",
                 "gross-weight-limit",
                 "towing-prohibited",
-                "permitted-oversize-loads-prohibi"
+                "permitted-oversize-loads-prohibited"
             ]
         },
         "roadDirection-enum": {
@@ -112,7 +112,8 @@
                         {
                             "required": ["startDateTime-cancelled"]
                         }
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "endDateTime": {
                     "description": "The time and date when a work zone ends",
@@ -150,7 +151,8 @@
                         {
                             "required": ["endDateTime-cancelled"]
                         }
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "beginLocation": {
                     "description": "The LOCATION when work zone impact begins along a single road in a single direction (see BeginLocation). The impact typically begins where the first channeling device (e.g., cone or barrel) is located.",
@@ -229,7 +231,8 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "endLocation": {
                     "description": "The LOCATION along a single road in a single direction when work zone impact ends and the traffic returns to normal (See EndLocation)",
@@ -291,7 +294,8 @@
                                 }
                             ]
                         }
-                    ]
+                    ],
+                    "additionalProperties": false
                 },
                 "wz_status": {
                     "allOf": [
@@ -372,9 +376,11 @@
                     "format": "date-time"
                 }    
             },
-            "required": ["identifier", "startDateTime", "endDateTime", "beginLocation", "endLocation", "closedLanes"]
+            "required": ["identifier", "startDateTime", "endDateTime", "beginLocation", "endLocation", "closedLanes"],
+            "additionalProperties": false
         }
     },
     "type": "array",
-    "items": {"$ref": "#/definitions/WZ-Activity"}
+    "items": {"$ref": "#/definitions/WZ-Activity"},
+    "additionalProperties": false
 }


### PR DESCRIPTION
## Changes
- Additional Properties in JSON are not allowed (reflected on schema)
- ReVAL is pinned to v.0.4.0
- All reference to django-data-ingest now points to ReVAL
- Upload reference sample data and responses